### PR TITLE
Added support for running this on PAAS providers, such as OpenShift

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Openshift is a platform-as-a-service from RedHat which enables you to very quick
 
 0. Setup an OpenShift account and download the rhc tools 
 1. Create a new app
-rhc app create minecraftdropletmanager php-5.4 --from-code https://github.com/andrewl/minecraft-droplet-manager
+  rhc app create minecraftdropletmanager php-5.4 --from-code https://github.com/andrewl/minecraft-droplet-manager
 2. Set the following environment variables using the command
-rhc env set VARIABLE=VALUE -a minecraftdropletmanager
+  rhc env set VARIABLE=VALUE -a minecraftdropletmanager
 |DO_CLIENT_ID|Your Digital Ocean API v1 Client ID|
 |DO_API|Your Digital Ocean API v1 Key|
 |DROPLET_NAME|The name of your droplet (eg my-minecraft-droplet)|

--- a/README.md
+++ b/README.md
@@ -81,17 +81,30 @@ Openshift is a platform-as-a-service from RedHat which enables you to very quick
 
 0. Setup an OpenShift account and download the rhc tools 
 1. Create a new app
-  rhc app create minecraftdropletmanager php-5.4 --from-code https://github.com/andrewl/minecraft-droplet-manager
-2. Set the following environment variables using the command
-  rhc env set VARIABLE=VALUE -a minecraftdropletmanager
-|DO_CLIENT_ID|Your Digital Ocean API v1 Client ID|
-|DO_API|Your Digital Ocean API v1 Key|
-|DROPLET_NAME|The name of your droplet (eg my-minecraft-droplet)|
-|DROPLET_SIZE|The size of your droplet (eg 2gb)|
-|DROPLET_LOCATION|The location of your droplet (eg london)|
-|MINECRAFT_PORT|The port minecraft is listening on (eg 25565)|
 
-NB Any settings that are present in the config.php file will overwrite the 
+    rhc app create minecraftdropletmanager php-5.4 --from-code https://github.com/andrewl/minecraft-droplet-manager
+
+2. Set the following environment variables using the command
+ 
+    rhc env set VARIABLE=VALUE -a minecraftdropletmanager
+
+DO_CLIENT_ID: Your Digital Ocean API v1 Client ID
+
+DO_API:Your Digital Ocean API v1 Key
+
+DROPLET_NAME: The name of your droplet (eg my-minecraft-droplet)
+
+DROPLET_SIZE: The size of your droplet (eg 2gb)
+
+DROPLET_LOCATION: The location of your droplet (eg london)
+
+MINECRAFT_PORT: The port minecraft is listening on (eg 25565)
+
+3. Visit http://minecraftdropletmanager-<YOUR-DOMAIN>.rhcloud.com and login using the password set in index.php
+
+@TODO: set password using environment variable 
+
+NB Any settings that are present in the config.php file will take precedent over the environment variables
 
 ### Credit
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ I am not able to test this in very many browsers. I can verify it works in Safar
 
 #### 1. Host this script somewhere and set up your Minecraft droplet.
 
+(See also, 'Running on Openshift below')
+
 You'll need a place to host the files that is not on the minecraft server you are controlling. The web host will need to have PHP available.
 
 Before configuring this script, set up your Minecraft server at [Digital Ocean](https://www.digitalocean.com). There are several options for this and Google is your friend.
@@ -74,10 +76,22 @@ A: You may be wondering what the "admin console" link is all about. This was spe
 
 This is a work in progress. I still need to add some robust error handling. That is coming soon.
 
-### To Install On OpenShift
+### Running On OpenShift
+Openshift is a platform-as-a-service from RedHat which enables you to very quickly websites and online services up-and-running with a minimal amount of fuss. See openshift.com for more information.
+
+0. Setup an OpenShift account and download the rhc tools 
+1. Create a new app
 rhc app create minecraftdropletmanager php-5.4 --from-code https://github.com/andrewl/minecraft-droplet-manager
+2. Set the following environment variables using the command
+rhc env set VARIABLE=VALUE -a minecraftdropletmanager
+|DO_CLIENT_ID|Your Digital Ocean API v1 Client ID|
+|DO_API|Your Digital Ocean API v1 Key|
+|DROPLET_NAME|The name of your droplet (eg my-minecraft-droplet)|
+|DROPLET_SIZE|The size of your droplet (eg 2gb)|
+|DROPLET_LOCATION|The location of your droplet (eg london)|
+|MINECRAFT_PORT|The port minecraft is listening on (eg 25565)|
 
-
+NB Any settings that are present in the config.php file will overwrite the 
 
 ### Credit
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ A: You may be wondering what the "admin console" link is all about. This was spe
 
 This is a work in progress. I still need to add some robust error handling. That is coming soon.
 
+### To Install On OpenShift
+rhc app create minecraftdropletmanager php-5.4 --from-code https://github.com/andrewl/minecraft-droplet-manager
+
+
+
 ### Credit
 
 This was inspired by the work of S-rc-C-d-

--- a/config.php
+++ b/config.php
@@ -25,7 +25,11 @@ http://hi.srccd.com/post/hosting-minecraft-on-digitalocean
 */
 $environmentVariableSettings = array(
   'doClientID' => 'DO_CLIENT_ID',
-  'doApi' => 'DO_API'
+  'doApi' => 'DO_API',
+  'dropletname' => 'DROPLET_NAME',
+  'dropletsize' => 'DROPLET_SIZE',
+  'dropletlocation' => 'DROPLET_LOCATION',
+  'minecraftport' => 'MINECRAFT_PORT',
 );
 
 // Digital Ocean v1 API client ID and API key
@@ -36,14 +40,19 @@ $doClientID="";
 $doApi="";
 
 // Droplet details
-$dropletname = "steve";
-$dropletsize = "2gb";
-$dropletlocation = "london";
+// Environment variable DROPLET_NAME
+$dropletname = "";
+// Environment variable DROPLET_SIZE
+$dropletsize = "";
+// Environment variable DROPLET_LOCATION
+$dropletlocation = "";
 
 // Port you are hosting minecraft from
+// Environment variable MINECRAFT_PORT
 $minecraftport = "25565";
 /* --------------------------------------------------*/
 
+// Try to load settings from environment variables if not set above
 foreach ($environmentVariableSettings as $setting => $environmentVariable) {
   if (!$$setting) {
     $$setting = getenv($environmentVariable);

--- a/config.php
+++ b/config.php
@@ -20,20 +20,32 @@ http://hi.srccd.com/post/hosting-minecraft-on-digitalocean
 */
 
 /* --------------------------------------------------*/
-/* Configure these variables                         */
+/* Configure these variables or set the relevant
+   environment variables
+*/
+$environmentVariableSettings = array(
+  'doClientID' => 'DO_CLIENT_ID',
+  'doApi' => 'DO_API'
+);
 
 // Digital Ocean v1 API client ID and API key
-$doClientID="abc123";
-$doApi="abc123";
+// Environment variable DO_CLIENT_ID
+$doClientID="";
+
+// Environment variable DO_API
+$doApi="";
 
 // Droplet details
-$dropletname = "minecraft";
-$dropletsize = "1gb";
-$dropletlocation = "nyc3";
+$dropletname = "steve";
+$dropletsize = "2gb";
+$dropletlocation = "london";
 
 // Port you are hosting minecraft from
 $minecraftport = "25565";
-
 /* --------------------------------------------------*/
 
-?>
+foreach ($environmentVariableSettings as $setting => $environmentVariable) {
+  if (!$$setting) {
+    $$setting = getenv($environmentVariable);
+  }
+}


### PR DESCRIPTION
Simple change, it enables the config options to be set using environment variables so that setting up on PAAS platforms such as OpenShift, Heroku can be done without making changes to the code.
